### PR TITLE
Simplify & refactor Vector2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16745,7 +16745,7 @@
 		},
 		"packages/core": {
 			"name": "koora",
-			"version": "0.0.1",
+			"version": "0.0.6",
 			"license": "MIT",
 			"dependencies": {
 				"lodash.debounce": "^4.0.8"

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,0 +1,28 @@
+{
+	"name": "koora",
+	"version": "0.0.8",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "koora",
+			"version": "0.0.8",
+			"license": "MIT",
+			"dependencies": {
+				"lodash.debounce": "^4.0.8"
+			}
+		},
+		"node_modules/lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		}
+	},
+	"dependencies": {
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		}
+	}
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "koora",
-	"version": "0.0.6",
+	"version": "0.0.8",
 	"description": "AssemblyScript Game Framework",
 	"exports": {
 		"./loader": "./dist/main.js"

--- a/packages/core/src-as/math/Vector2.ts
+++ b/packages/core/src-as/math/Vector2.ts
@@ -1,87 +1,144 @@
 import { PolarCoords } from './PolarCoords'
 import { Vector3 } from './Vector3'
 
-
-
-export class Vector2{
-	
-	static fromPolar(polar: PolarCoords, target: Vector2 = new Vector2()): Vector2{
+export class Vector2 {
+	static fromPolar(polar: PolarCoords, target: Vector2 = new Vector2()): Vector2 {
 		target.x = Mathf.cos(polar.angle) * polar.radius
 		target.y = Mathf.sin(polar.angle) * polar.radius
 		return target
 	}
-	get x(): f32{ return this.m[0] } set x(val: f32){ this.m[0] = val }
-	get y(): f32{ return this.m[1] } set y(val: f32){ this.m[1] = val }
 
-	m: Float32Array
-	constructor(x: f32 = 0, y: f32 = 0){
-		this.m = new Float32Array(2)
-		this.m[0] = x
-		this.m[1] = y
+	constructor(
+		public x: f32 = 0,
+		public y: f32 = 0
+	) {}
+	// @ts-ignore: decorator
+	@inline
+	clone(ref: Vector2 = new Vector2()): Vector2 {
+		ref.x = this.x
+		ref.y = this.y
+		return ref
 	}
-	clone(ref: Vector2 = new Vector2()): Vector2{
-		ref.x = this.x; ref.y = this.y; return ref }
-	set(x: f32, y: f32): Vector2 { 
-		this.x = x; this.y = y; return this }
-
-	lengthSquared(): f32 {	
-		return this.x * this.x + this.y * this.y }
-	length(): f32{
-		return Mathf.sqrt(this.x * this.x + this.y * this.y)
+	// @ts-ignore: decorator
+	@inline
+	set(x: f32, y: f32): this {
+		this.x = x
+		this.y = y
+		return this
 	}
-	toPolar (): PolarCoords {
+	// @ts-ignore: decorator
+	@inline
+	lengthSquared(): f32 {
+		return this.x * this.x + this.y * this.y
+	}
+	// @ts-ignore: decorator
+	@inline
+	length(): f32 {
+		return Mathf.sqrt(this.lengthSquared())
+	}
+	// @ts-ignore: decorator
+	@inline
+	toPolar(): PolarCoords {
 		return new PolarCoords(
 			Mathf.atan2(this.y, this.x),
-			this.length())
+			this.length()
+		)
 	}
-	toVector3(target: Vector3 = new Vector3()): Vector3{
+	// @ts-ignore: decorator
+	@inline
+	toVector3(target: Vector3 = new Vector3()): Vector3 {
 		target.x = this.x
 		target.y = this.y
 		target.z = 0
 		return target
 	}
+	// @ts-ignore: decorator
+	@inline
 	toVector3XZ(target: Vector3 = new Vector3()): Vector3{
 		target.x = this.x
 		target.y = 0
 		target.z = this.y
 		return target
 	}
-	// @operator('+')
-	addRef (b: Vector2, o: Vector2 = new Vector2()): Vector2
-	{ o.x = this.x + b.x; o.y = this.y + b.y; return o }
-	// @operator('-')
-	subRef (b: Vector2, o: Vector2 = new Vector2()): Vector2 
-	{ o.x = this.x - b.x; o.y = this.y - b.y; return o }
-	// @operator('*')
-	multRef (b: Vector2, o: Vector2 = new Vector2()): Vector2 
-	{ o.x = this.x * b.x; o.y = this.y * b.y; return o }
-	// @operator('/')
-	divRef (b: Vector2, o: Vector2 = new Vector2()): Vector2 
-	{ o.x = this.x / b.x; o.y = this.y / b.y; return o }
+	// @ts-ignore: decorator
+	@inline @operator('+')
+	addRef(b: Vector2, o: Vector2 = new Vector2()): Vector2 {
+		o.x = this.x + b.x
+		o.y = this.y + b.y
+		return o
+	}
+	// @ts-ignore: decorator
+  @inline @operator('-')
+	subRef(b: Vector2, o: Vector2 = new Vector2()): Vector2 {
+		o.x = this.x - b.x
+		o.y = this.y - b.y
+		return o
+	}
+	// @ts-ignore: decorator
+  @inline @operator('*')
+  multRef(b: Vector2, o: Vector2 = new Vector2()): Vector2 {
+  	o.x = this.x * b.x
+  	o.y = this.y * b.y
+  	return o
+  }
+	// @ts-ignore: decorator
+	@inline @operator('/')
+  divRef(b: Vector2, o: Vector2 = new Vector2()): Vector2 {
+  	o.x = this.x / b.x
+  	o.y = this.y / b.y
+  	return o
+  }
 	//TODO make all sets static
-	static add (a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2
-	{ ref.x = a.x + b.x; ref.y = a.y + b.y; return ref }
-	static sub (a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2 
-	{ ref.x = a.x - b.x; ref.y = a.y - b.y; return ref }
-	static mult (a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2 
-	{ ref.x = a.x * b.x; ref.y = a.y * b.y; return ref }
-	static div (a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2 
-	{ ref.x = a.x / b.x; ref.y = a.y / b.y; return ref }
-	add (b: Vector2): Vector2
-	{ this.x += b.x; this.y += b.y; return this }
-	sub (b: Vector2): Vector2 
-	{ this.x -= b.x; this.y -= b.y; return this }
-	mult (b: Vector2): Vector2 
-	{ this.x *= b.x; this.y *= b.y; return this }
-	div (b: Vector2): Vector2 
-	{ this.x /= b.x; this.y /= b.y; return this }
-	addValue (b: f32): Vector2
-	{ this.x += b;	this.y += b; return this }
-	subValue (b: f32): Vector2
-	{ this.x -= b;	this.y -= b; return this }
-	scale (b: f32): Vector2
-	{ this.x *= b;	this.y *= b; return this }
-	scaleDiv (b: f32): Vector2
-	{ this.x /= b; this.y /= b; return this }
-	
+	// @ts-ignore: decorator
+	@inline
+	static add(a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2 {
+		ref.x = a.x + b.x
+		ref.y = a.y + b.y
+		return ref
+	}
+	// @ts-ignore: decorator
+	@inline
+	static sub(a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2 {
+		ref.x = a.x - b.x
+		ref.y = a.y - b.y
+		return ref
+	}
+	// @ts-ignore: decorator
+	@inline
+	static mult(a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2 {
+		ref.x = a.x * b.x
+		ref.y = a.y * b.y
+		return ref
+	}
+	// @ts-ignore: decorator
+	@inline
+	static div(a: Vector2, b: Vector2, ref: Vector2 = new Vector2()): Vector2 {
+		ref.x = a.x / b.x
+		ref.y = a.y / b.y
+		return ref
+	}
+	// @ts-ignore: decorator
+	@inline
+	add(b: Vector2): Vector2 { this.x += b.x; this.y += b.y; return this }
+	// @ts-ignore: decorator
+	@inline
+	sub(b: Vector2): Vector2 { this.x -= b.x; this.y -= b.y; return this }
+	// @ts-ignore: decorator
+	@inline
+	mult(b: Vector2): Vector2 { this.x *= b.x; this.y *= b.y; return this }
+	// @ts-ignore: decorator
+	@inline
+	div(b: Vector2): Vector2 { this.x /= b.x; this.y /= b.y; return this }
+	// @ts-ignore: decorator
+	@inline
+	addValue(b: f32): Vector2 { this.x += b;	this.y += b; return this }
+	// @ts-ignore: decorator
+	@inline
+	subValue(b: f32): Vector2 { this.x -= b;	this.y -= b; return this }
+	// @ts-ignore: decorator
+	@inline
+	scale(b: f32): Vector2 { this.x *= b;	this.y *= b; return this }
+	// @ts-ignore: decorator
+	@inline
+	scaleDiv(b: f32): Vector2 { this.x /= b; this.y /= b; return this }
 }


### PR DESCRIPTION
Better avoid aggregated TypedArrays inside Math primitives like Vector2, Matrix, Quaternion and etc. In AS much more efficiently when you have less indirections. Also TypedArrays required bounds checks which also not efficient. So as example I refactored and simplify Vector2 class. It is better to refactor all other primitives in Math using the same example